### PR TITLE
Add modified field to Game

### DIFF
--- a/src/main/java/com/badlogicgames/libgdx/site/db/Game.java
+++ b/src/main/java/com/badlogicgames/libgdx/site/db/Game.java
@@ -9,6 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class Game {
 	public String id;
 	public Date created;
+	public Date modified;
 	public String title;
 	public String creator;
 	public String description;

--- a/src/main/java/com/badlogicgames/libgdx/site/db/InMemoryGameDatabase.java
+++ b/src/main/java/com/badlogicgames/libgdx/site/db/InMemoryGameDatabase.java
@@ -43,7 +43,7 @@ public class InMemoryGameDatabase implements GameDatabase {
 		String id = tokensToIds.get(token);
 		if(id == null) return false;
 		game.id = id;
-		game.created = new Date();
+		game.modified = new Date();
 		idsToGames.put(id, game);
 		return true;
 	}


### PR DESCRIPTION
Previously, on updating an entry the created date would be changed. This
had the effect of pushing recently updated entries to the top of the
gallery page and allowed folks to keep their game listed first by updating
their entry. While I'd hope this would be a non-issue, it is probably best
to guard against it.
