### PR TITLE
Fix oddly positioned logos.

### DIFF
--- a/src/main/webapp/features.html
+++ b/src/main/webapp/features.html
@@ -52,9 +52,9 @@
       
       <div class="well">
       	<h2>3rd Party Support</h2>
-      	<a href="http://swarmconnect.com/admin/docs/libgdx/"><img class="well" src="http://swarmconnect.com/images/site/logo.png"></img></a>
-      	<a href="https://developers.nextpeer.com/docs/view/libgdx/"><img class="well" src="http://nextpeer.com/css/img/logo.png"></img></a>
       	<p>Libgdx can be integrated with many 3rd party libraries, e.g. for adding leaderboards or multiplayer. We love:</p>
+      		<a href="http://swarmconnect.com/admin/docs/libgdx/"><img class="well" src="http://swarmconnect.com/images/site/logo.png"></img></a>
+      	<a href="https://developers.nextpeer.com/docs/view/libgdx/"><img class="well" src="http://nextpeer.com/css/img/logo.png"></img></a>
       </div>
       
       <div class="well">        


### PR DESCRIPTION
The logos for Swarm and Nextpeer should appear below the description text not above.
