### PR TITLE
Fixed link for LibGDX game development by example

### DIFF
--- a/src/main/webapp/documentation.html
+++ b/src/main/webapp/documentation.html
@@ -134,7 +134,7 @@
 	<div class="one-of-four">
 		<center>
 			<a
-				href="http://www.amazon.com/dp/1785281445/"><img
+				href=https://www.packtpub.com/game-development/libgdx-game-development-example><img
 				style="width: 300px" src="img/libgdxbyexample.jpg"></a>
 		</center>
 	</div>

--- a/src/main/webapp/documentation.html
+++ b/src/main/webapp/documentation.html
@@ -134,7 +134,7 @@
 	<div class="one-of-four">
 		<center>
 			<a
-				href=https://www.packtpub.com/game-development/libgdx-game-development-example><img
+				href="https://www.packtpub.com/game-development/libgdx-game-development-example"><img
 				style="width: 300px" src="img/libgdxbyexample.jpg"></a>
 		</center>
 	</div>


### PR DESCRIPTION
Fixed link to amazon for LibGDX Game Development by Example. Packtpub is the publisher that accepts the code, not Amazon