### PR TITLE
Update gulp and dependencies

### DIFF
--- a/src/main/docs/gulpfile.js
+++ b/src/main/docs/gulpfile.js
@@ -34,14 +34,14 @@ function TokenMap (document, fullpath) {
 }
 
 
-gulp.task("clean", function() {
+gulp.task("clean", async function() {
     return del.sync(['dist/index.html']);
 });
 
-gulp.task("templates", ['clean'], function () {
+gulp.task("templates", gulp.series(['clean'], async function () {
     return gulp.src(['src/docs/**/*.md'])
     .pipe(data(function(file) {
-        var template = new Buffer(fs.readFileSync("templates/default"));
+        var template = Buffer.from(fs.readFileSync("templates/default"));
 
         var content = frontmatter(String(file.contents));
 
@@ -94,36 +94,36 @@ gulp.task("templates", ['clean'], function () {
     }))
     .pipe(swig({ defaults: {autoescape: false, cache: false} }))
     .pipe(gulp.dest('dist/documentation'));
-});
+}));
 
-gulp.task('css', function() {
+gulp.task('css', async function() {
     return gulp.src(['src/css/**.css'])
     .pipe(gulp.dest('dist/css/'));
 });
 
 
-gulp.task('js', function() {
+gulp.task('js', async function() {
     return gulp.src(['src/js/**.js'])
     .pipe(gulp.dest('dist/js/'));
 });
 
-gulp.task('img', function() {
+gulp.task('img', async function() {
     return gulp.src(['src/img/**'])
     .pipe(gulp.dest('dist/img/'));
 });
 
-gulp.task("index", ['templates'], function () {
+gulp.task("index", gulp.series(['templates'], async function () {
     fs.writeFile("dist/documentation/documentation_index", JSON.stringify(globalTokens), "UTF-8");
-})
+}))
 
-gulp.task('build', ['templates', 'img', 'css', 'js', 'index'])
+gulp.task('build', gulp.series(['templates', 'img', 'css', 'js', 'index']))
 
-gulp.task('deploy', ['build'], function () {
+gulp.task('deploy', gulp.series(['build'], async function () {
     del.sync(['deploy/']);
     gulp.src(['dist/documentation/**/*']).pipe(gulp.dest('deploy/documentation'));
-})
+}))
 
-gulp.task('serve', ['build'], function() {
+gulp.task('serve', gulp.series(['build'], async function() {
 
     browsersync.init({
         server: "./dist",
@@ -131,6 +131,6 @@ gulp.task('serve', ['build'], function() {
         scrollRestoreTechnique: 'cookie'
     });
 
-    gulp.watch(['src/**', 'templates/**'], ['build']);
+    gulp.watch(['src/**', 'templates/**'], gulp.series(['build']));
     gulp.watch("dist/**").on('change', browsersync.reload);
-});
+}));

--- a/src/main/docs/package.json
+++ b/src/main/docs/package.json
@@ -5,14 +5,14 @@
   "author": "Tomski",
   "license": "Apache-2.0",
   "dependencies": {
-    "browser-sync": "^2.18.13",
-    "del": "^3.0.0",
-    "front-matter": "^2.2.0",
-    "fs-extra": "^4.0.1",
-    "gulp": "^3.9.1",
-    "gulp-data": "^1.2.1",
-    "gulp-swig": "^0.8.0",
-    "marked": "^0.3.6",
+    "browser-sync": "^2.26.7",
+    "del": "^5.1.0",
+    "front-matter": "^3.1.0",
+    "fs-extra": "^9.0.0",
+    "gulp": "^4.0.2",
+    "gulp-data": "^1.3.1",
+    "gulp-swig": "^0.9.1",
+    "marked": "^1.0.0",
     "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
Because gulp v3 does not work with the latest Node.js 12 LTS release (see [travis log](https://travis-ci.com/github/SimonIT/libgdx-site/jobs/326665414)), I updated it to gulp v4

```javascript
fs.js:35
} = primordials;
    ^

ReferenceError: primordials is not defined
    at fs.js:35:5
    at req_ (libgdx-site\src\main\docs\node_modules\natives\index.js:143:24)
    at Object.req [as require] (libgdx-site\src\main\docs\node_modules\natives\index.js:55:10)
    at Object.<anonymous> (libgdx-site\src\main\docs\node_modules\vinyl-fs\node_modules\graceful-fs\fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:1156:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1176:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Module.require (internal/modules/cjs/loader.js:1042:19)
    at require (internal/modules/cjs/helpers.js:77:18)
```