### PR TITLE
Correct "Working from Source Guide"-link

### DIFF
--- a/src/main/webapp/src/source.html
+++ b/src/main/webapp/src/source.html
@@ -22,6 +22,6 @@
 			<p>Many examples and demos can be found in libgdx's repository. You may also want to inspect and modify libgdx's source code. For both
 			cases, we recommend checking out the source guide on the wiki.
 			</p>
-			<a class="btn" href="https://github.com/libgdx/libgdx/wiki/Running-demos-%26-tests"><i class="icon-github"></i>&nbsp;Working from Source Guide</a>
+			<a class="btn" href="documentation/hacking/Working%20from%20source.html"><i class="icon-github"></i>&nbsp;Working from Source Guide</a>
 	</div>
 </div>


### PR DESCRIPTION
The old link points to a deprecated github page